### PR TITLE
Increase the default timeout value for Tika to 20 sec

### DIFF
--- a/modules/entity_to_text_tika/src/Extractor/FileToText.php
+++ b/modules/entity_to_text_tika/src/Extractor/FileToText.php
@@ -111,6 +111,7 @@ class FileToText {
   public function getClient(string $param1 = NULL, $param2 = NULL, array $options = [], bool $check = TRUE): Client {
     if (!$this->client) {
       $this->client = Client::make($param1, $param2, $options, $check);
+      $this->client->setTimeout(20);
     }
 
     return $this->client;


### PR DESCRIPTION
Tika extraction data can take a while, let's increase the default timeout value for Tika to 20 seconds