### PR TITLE
add event PRE_PROCESS_FILE to allow client or file alteration before Tika OCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fix D10 deprecations: Creation of dynamic property is deprecated
 
+### Added
+- add event PRE_PROCESS_FILE to allow client or file alteration before Tika OCR
+
 ## [1.0.0] - 2023-01-27
 ### Added
 - init module

--- a/modules/entity_to_text_tika/entity_to_text_tika.services.yml
+++ b/modules/entity_to_text_tika/entity_to_text_tika.services.yml
@@ -7,3 +7,4 @@ services:
       - '@settings'
       - '@file_system'
       - '@logger.factory'
+      - '@event_dispatcher'

--- a/modules/entity_to_text_tika/src/Event/EntityToTextTikaEvents.php
+++ b/modules/entity_to_text_tika/src/Event/EntityToTextTikaEvents.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\entity_to_text_tika\Event;
+
+/**
+ * Defines events for the Entity To Text Tika module.
+ */
+final class EntityToTextTikaEvents {
+
+  /**
+   * Allow to alter the client configurations or the file before OCR.
+   *
+   * @Event
+   *
+   * @see \Drupal\entity_to_text_tika\Event\PreProcessFileEvent
+   */
+  const PRE_PROCESS_FILE = 'entity_to_text_tika.preprocess_file';
+
+}

--- a/modules/entity_to_text_tika/src/Event/PreProcessFileEvent.php
+++ b/modules/entity_to_text_tika/src/Event/PreProcessFileEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\entity_to_text_tika\Event;
+
+use Vaites\ApacheTika\Client;
+use Drupal\file\Entity\File;
+use Drupal\Component\EventDispatcher\Event;
+
+/**
+ * Event fired just before processing a file through Tika.
+ *
+ * Allow you to alter the client configurations or the file before OCR.
+ */
+class PreProcessFileEvent extends Event {
+
+  /**
+   * The Apache Tika client.
+   *
+   * @var \Vaites\ApacheTika\Client
+   */
+  protected $client;
+
+  /**
+   * The Drupal file to be processed by Tika OCR.
+   *
+   * @var \Drupal\file\Entity\File
+   */
+  protected $file;
+
+  /**
+   * Constructs a PreProcessFileEvent object.
+   *
+   * @param \Vaites\ApacheTika\Client $client
+   *   The Apache Tika client.
+   * @param \Drupal\file\Entity\File $file
+   *   The Drupal file to be processed by Tika OCR.
+   */
+  public function __construct(Client $client, File $file) {
+    $this->client = $client;
+    $this->file = $file;
+  }
+
+  /**
+   * Get the Apache Tika client.
+   *
+   * @return \Vaites\ApacheTika\Client
+   *   The Apache Tika client.
+   */
+  public function getClient(): Client {
+    return $this->client;
+  }
+
+  /**
+   * Get the Drupal file.
+   *
+   * @return \Drupal\file\Entity\File
+   *   The Drupal file object.
+   */
+  public function getFile(): File {
+    return $this->file;
+  }
+
+}

--- a/modules/entity_to_text_tika/tests/src/Unit/EntityToTextTikaEventsTest.php
+++ b/modules/entity_to_text_tika/tests/src/Unit/EntityToTextTikaEventsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\Tests\entity_to_text_tika\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\entity_to_text_tika\Event\EntityToTextTikaEvents;
+
+/**
+ * @coversDefaultClass \Drupal\entity_to_text_tika\Event\EntityToTextTikaEvents
+ *
+ * @group entity_to_text
+ * @group entity_to_text_tika
+ */
+class EntityToTextTikaEventsTest extends UnitTestCase {
+
+  /**
+   * @covers \Drupal\entity_to_text_tika\Event\EntityToTextTikaEvents
+   *
+   * @dataProvider eventNames
+   */
+  public function testEventNames($event_name, $expected) {
+    $this->assertEquals($expected, $event_name);
+  }
+
+  /**
+   * List of supported event with expected names.
+   *
+   * @return array
+   *   The list of CONST names & string expected value.
+   */
+  public function eventNames() {
+    return [
+      [
+        EntityToTextTikaEvents::PRE_PROCESS_FILE,
+        'entity_to_text_tika.preprocess_file',
+      ],
+    ];
+  }
+
+}

--- a/modules/entity_to_text_tika/tests/src/Unit/PreProcessFileEventTest.php
+++ b/modules/entity_to_text_tika/tests/src/Unit/PreProcessFileEventTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Drupal\Tests\entity_to_text_tika\Unit;
+
+use Drupal\entity_to_text_tika\Event\EntityToTextTikaEvents;
+use Prophecy\Prophecy\ObjectProphecy;
+use Drupal\entity_to_text_tika\Event\PreProcessFileEvent;
+use Drupal\entity_to_text_tika\Extractor\FileToText;
+use Drupal\Tests\UnitTestCase;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Site\Settings;
+use Drupal\file\Entity\File;
+use Psr\Log\LoggerInterface;
+use Vaites\ApacheTika\Clients\WebClient;
+use Prophecy\Prophet;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @coversDefaultClass \Drupal\entity_to_text_tika\Event\PreProcessFileEvent
+ *
+ * @group entity_to_text
+ * @group entity_to_text_tika
+ */
+class PreProcessFileEventTest extends UnitTestCase {
+  /**
+   * A mocked instance of a Tika client.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy|\Vaites\ApacheTika\Clients\WebClient
+   */
+  protected $client;
+
+  /**
+   * The event dispatcher.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy|\Symfony\Contracts\EventDispatcher\EventDispatcherInterface
+   */
+  private $eventDispatcher;
+
+  /**
+   * The prophecy object.
+   *
+   * @var \Prophecy\Prophet
+   */
+  private $prophet;
+
+  /**
+   * The File To Text extractor.
+   *
+   * @var \Drupal\entity_to_text_tika\Extractor\FileToText
+   */
+  private $fileToText;
+
+  /**
+   * The file used for testing.
+   *
+   * @var \Drupal\Tests\entity_to_text_tika\Unit\File|\Prophecy\Prophecy\ObjectProphecy
+   */
+  private ObjectProphecy|File $testFile;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->prophet = new Prophet();
+    $settings['entity_to_text_tika.connection']['host'] = 'tika';
+    $settings['entity_to_text_tika.connection']['port'] = '9998';
+    $settings = new Settings($settings);
+
+    $this->client = $this->prophet->prophesize(WebClient::class);
+    $fileSystem = $this->prophet->prophesize(FileSystemInterface::class);
+    $loggerFactory = $this->prophet->prophesize(LoggerChannelFactoryInterface::class);
+    $logger = $this->prophet->prophesize(LoggerInterface::class);
+    $this->eventDispatcher = $this->prophet->prophesize(EventDispatcherInterface::class);
+
+    $loggerFactory->get('entity_to_text')
+      ->willReturn($logger->reveal());
+
+    // Create a test file object.
+    $this->testFile = $this->prophet->prophesize(File::class);
+    $this->testFile->getFileUri()
+      ->willReturn('public://file/test.txt')
+      ->shouldBeCalled();
+
+    $fileSystem->realpath('public://file/test.txt')
+      ->willReturn('/var/www/web/sites/default/files/file/test.txt')
+      ->shouldBeCalled();
+
+    $this->client->getText('/var/www/web/sites/default/files/file/test.txt')
+      ->willReturn('Commodo duis lorem vestibulum imperdiet vel hac')
+      ->shouldBeCalled();
+    $this->client->setOCRLanguage('eng')->shouldBeCalled();
+
+    $this->fileToText = new FileToText($settings, $fileSystem->reveal(), $loggerFactory->reveal(), $this->eventDispatcher->reveal());
+    $this->fileToText->setClient($this->client->reveal());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    parent::tearDown();
+
+    $this->prophet->checkPredictions();
+  }
+
+  /**
+   * Ensure the PreProcessFileEvent is triggered once on FileToText extractor.
+   */
+  public function testFileToTextTrigger(): void {
+    // The event that must be dispatch.
+    $event = new PreProcessFileEvent($this->client->reveal(), $this->testFile->reveal());
+
+    $this->eventDispatcher->dispatch($event, EntityToTextTikaEvents::PRE_PROCESS_FILE)
+      ->willReturn($event)
+      ->shouldBeCalled();
+    $this->fileToText->fromFileToText($this->testFile->reveal());
+  }
+
+}


### PR DESCRIPTION
### 💬 Description
add event PRE_PROCESS_FILE to allow client or file alteration before Tika OCR

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
