### PR TITLE
drop support of drupal below 9.5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.4', '9.5', '10.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2']
         module: ['entity_to_text']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- drop support of drupal below 9.5.x
+
 ### Changed
 - increase timeout to 20sec
 
 ### Fixed
 - fix D10 deprecations: Creation of dynamic property is deprecated
 
-### Added
+### Added
 - add event PRE_PROCESS_FILE to allow client or file alteration before Tika OCR
 
 ## [1.0.0] - 2023-01-27

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ globally on your environment:
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker-compose build --pull --build-arg BASE_IMAGE_TAG=9.5 drupal
+    docker-compose build --pull --build-arg BASE_IMAGE_TAG=10.2 drupal
     (get a coffee, this will take some time...)
     docker-compose up -d drupal
     docker-compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-ARG BASE_IMAGE_TAG=9.5
+ARG BASE_IMAGE_TAG=10.2
 FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 
 ARG BASE_IMAGE_TAG
 ENV BASE_IMAGE_TAG=${BASE_IMAGE_TAG}
 
-# Disable deprecation notice.
-# ENV SYMFONY_DEPRECATIONS_HELPER=disabled
+# Disable deprecation notice since PHPUnit 10 with Drupal 10.2 and upper.
+# @see https://www.drupal.org/project/drupal/issues/3403491
+ENV SYMFONY_DEPRECATIONS_HELPER=weak
+
 
 # Install ezyang/htmlpurifier as required by entity_to_text
 RUN COMPOSER_MEMORY_LIMIT=-1 composer require "ezyang/htmlpurifier:^4.14"

--- a/entity_to_text.info.yml
+++ b/entity_to_text.info.yml
@@ -2,4 +2,4 @@ name: Entity to Text
 type: module
 description: 'Provides a number of utility and helper APIs for developers to transform content into plain text.'
 package: Search
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.5 || ^10


### PR DESCRIPTION
### 💬 Description
drop support of drupal below 9.5.x

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
