### PR TITLE
update drupal version support (drop 9.x and < 10.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         run: docker compose -f docker-compose.yml exec -T -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
       - name: Run unit tests
         run: docker compose -f docker-compose.yml run -u www-data drupal phpunit --no-coverage --group=${{ matrix.module }} --exclude-group=${{ matrix.module }}_functional --configuration=/var/www/html/phpunit.xml
+        continue-on-error: ${{ matrix.experimental }}
 
   tests-functional:
     name: Functional Tests
@@ -66,6 +67,7 @@ jobs:
         run: docker compose -f docker-compose.yml exec -T -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
       - name: Run tests
         run: docker compose -f docker-compose.yml exec -T -u www-data drupal phpunit --no-coverage --group=${{ matrix.module }}_functional --configuration=/var/www/html/phpunit.xml
+        continue-on-error: ${{ matrix.experimental }}
 
   upgrade-status:
     name: Upgrade Status


### PR DESCRIPTION
### 💬 Description
update drupal version support (drop 9.x and < 10.3)


- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
