### PR TITLE
refactor(hook): use new hook runtime and mark the old one as legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- refactor(hook): use new hook runtime and mark the old one as legacy
 
 ## [1.3.1] - 2026-02-25
 ### Removed

--- a/modules/entity_to_text_tika/entity_to_text_tika.install
+++ b/modules/entity_to_text_tika/entity_to_text_tika.install
@@ -5,41 +5,26 @@
  * Install, update and uninstall fn for the Entity to Text Tika sub-module.
  */
 
+use Drupal\Core\Hook\Attribute\LegacyRequirementsHook;
+use Drupal\entity_to_text_tika\Hook\EntityToTextTikaRequirementsHook;
+
 /**
  * Implements hook_requirements().
+ *
+ * @deprecated in drupal:11.2.0 and is removed from drupal:12.0.0. Use
+ *   hook_runtime_requirements() for runtime checks instead.
+ *
+ * @see https://www.drupal.org/node/3490851
  */
+#[LegacyRequirementsHook]
 function entity_to_text_tika_requirements($phase = 'runtime') {
-  $requirements = [];
+  if ($phase !== 'runtime') {
+    return [];
+  }
+
   $stream_wrapper_manager = \Drupal::service('stream_wrapper_manager');
   $file_system = \Drupal::service('file_system');
+  $hook = new EntityToTextTikaRequirementsHook($stream_wrapper_manager, $file_system);
 
-  /* ************************************************************************ */
-  // Check private file directory.
-  /* ************************************************************************ */
-
-  if ($phase !== 'runtime') {
-    return $requirements;
-  }
-
-  $requirements['entity_to_text_tika_private'] = [
-    'title' => t('Entity to Text (Tika): Local File Storage (OCR cache)'),
-    'description' => t('Entity to Text Tika expose a Local File Storage optimisation in order to store OCR of document in the private:// schema. The current private schema configuration can leverage it.'),
-    'value' => t('Private file system is set and writtable.'),
-  ];
-
-  // Check if the private file stream wrapper is ready to use.
-  if (!$stream_wrapper_manager->isValidScheme('private')) {
-    $requirements['entity_to_text_tika_private']['value'] = 'Private file system is not set.';
-    $requirements['entity_to_text_tika_private']['description'] = t('Entity to Text Tika expose a Local File Storage optimisation in order to store OCR of document in the private:// schema. The current private schema configuration cannot leverage it.');
-    $requirements['entity_to_text_tika_private']['severity'] = REQUIREMENT_INFO;
-  }
-
-  $private_path = $file_system->realpath('private://');
-  // Check if the private file stream wrapper is ready to use.
-  if (!is_dir($private_path) || !is_writable($private_path)) {
-    $requirements['entity_to_text_tika_private']['value'] = t('Entity to Text Tika expose a Local File Storage optimisation in order to store OCR of document in the private:// schema. The current private schema configuration cannot leverage it. The resolved private directory %directory% seems not writable.', ['%directory%' => $private_path]);
-    $requirements['entity_to_text_tika_private']['severity'] = REQUIREMENT_ERROR;
-  }
-
-  return $requirements;
+  return $hook->runtime();
 }

--- a/modules/entity_to_text_tika/src/Hook/EntityToTextTikaRequirementsHook.php
+++ b/modules/entity_to_text_tika/src/Hook/EntityToTextTikaRequirementsHook.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\entity_to_text_tika\Hook;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * RuntimeRequirements for entity to text tika.
+ */
+final class EntityToTextTikaRequirementsHook {
+  use StringTranslationTrait;
+
+  public function __construct(protected readonly StreamWrapperManagerInterface $streamWrapperManager, protected readonly FileSystemInterface $fileSystem) {
+  }
+
+  /**
+   * Implements hook_runtime_requirements().
+   */
+  #[Hook('runtime_requirements')]
+  public function runtime(): array {
+    $requirements = [];
+
+    $requirements['entity_to_text_tika_private'] = [
+      'title' => $this->t('Entity to Text (Tika): Local File Storage (OCR cache)'),
+      'description' => $this->t('Entity to Text Tika expose a Local File Storage optimisation in order to store OCR of document in the private:// schema. The current private schema configuration can leverage it.'),
+      'value' => $this->t('Private file system is set and writtable.'),
+    ];
+
+    // Check if the private file stream wrapper is ready to use.
+    if (!$this->streamWrapperManager->isValidScheme('private')) {
+      $requirements['entity_to_text_tika_private']['value'] = 'Private file system is not set.';
+      $requirements['entity_to_text_tika_private']['description'] = $this->t('Entity to Text Tika expose a Local File Storage optimisation in order to store OCR of document in the private:// schema. The current private schema configuration cannot leverage it.');
+      $requirements['entity_to_text_tika_private']['severity'] = REQUIREMENT_INFO;
+    }
+
+    $private_path = $this->fileSystem->realpath('private://');
+    // Check if the private file stream wrapper is ready to use.
+    if (!is_dir($private_path) || !is_writable($private_path)) {
+      $requirements['entity_to_text_tika_private']['value'] = $this->t('Entity to Text Tika expose a Local File Storage optimisation in order to store OCR of document in the private:// schema. The current private schema configuration cannot leverage it. The resolved private directory %directory% seems not writable.', ['%directory%' => $private_path]);
+      $requirements['entity_to_text_tika_private']['severity'] = REQUIREMENT_ERROR;
+    }
+
+    return $requirements;
+  }
+
+}


### PR DESCRIPTION
### 💬 Description
refactor(hook): use new hook runtime and mark the old one as legacy

### 🎟️ Doc(s)
- https://www.drupal.org/node/3490851
- https://www.md-systems.ch/en/blog/2025-10-19/converting-legacy-hooks
- https://dev.to/xwero/new-drupal-hook-attribute-34n0

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
